### PR TITLE
セキュリティの向上

### DIFF
--- a/app/controllers/tweets_controller.rb
+++ b/app/controllers/tweets_controller.rb
@@ -1,4 +1,5 @@
 class TweetsController < ApplicationController
+  before_action :move_to_index,except: [:index]
   def new
     @tweet = Tweet.new
   end
@@ -26,5 +27,8 @@ class TweetsController < ApplicationController
   private
   def tweet_params
     params.require(:tweet).permit(:image, :text)
+  end
+  def move_to_index
+    redirect_to action: :index unless user_signed_in?
   end
 end


### PR DESCRIPTION
What
Tweetsコントローラでbefore actionを設定し、index画面以外にアクセスできないようにした
Why
不正アクセスを防ぐため