### PR TITLE
ユーザー情報更新機能の編集

### DIFF
--- a/app/assets/stylesheets/users/sigin_up.scss
+++ b/app/assets/stylesheets/users/sigin_up.scss
@@ -96,6 +96,17 @@
         @include fieldBanner;
       }
     }
+
+    .signup-password-current{
+      margin: 10px;
+      .signup-password-current__label{
+        margin: 5px;
+      }
+      .signup-password-current__field{
+        @include fieldBanner;
+      }
+    }
+
     .signup-submit{
       margin: 10px;
       &__btn{

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,5 +4,6 @@ class ApplicationController < ActionController::Base
 
   def configure_permitted_parameters
     devise_parameter_sanitizer.permit(:sign_up, keys: [:nickname, :username, :image, :profile])
+    devise_parameter_sanitizer.permit(:account_update, keys: [:nickname, :username, :image, :profile])
   end
 end

--- a/app/views/devise/registrations/edit.html.haml
+++ b/app/views/devise/registrations/edit.html.haml
@@ -30,17 +30,24 @@
         = f.label :email, class: 'signup-email__label'
         %br/
         = f.email_field :email, class: 'signup-email__email_field'
+
       .signup-password
-        = f.label :password, class: 'signup-password__label'
+        = f.label :New_password, class: 'signup-password__label'
         - if @validatable
           %em
             (#{@minimum_password_length} characters minimum)
         %br/
         = f.password_field :password, autocomplete: "off", class: 'signup-password__password_field'
+
       .signup-password-confirmation
-        = f.label :password_confirmation, class: 'signup-password-confirmation__label'
+        = f.label :New_password_confirmation, class: 'signup-password-confirmation__label'
         %br/
         = f.password_field :password_confirmation, autocomplete: "off", class: 'signup-password-confirmation__password_field'
+
+      .signup-password-current
+        = f.label :current_password, class: 'signup-password-current__label'
+        = f.password_field :current_password, autocomplete: "current-password", class: 'signup-password-current__field'
+
       .signup-submit
         = f.submit "Update", class: 'signup-submit__btn'
 


### PR DESCRIPTION
What
ユーザー情報更新画面の編集をした
現在のパスワードを入力させる画面を追加した
Deviseのデフォルトの項目から追加したものに関しても更新できるようにapplication_controllerに新しい項目を追加した
Why
ユーザーが自身の情報を更新できるようにするため